### PR TITLE
Sign all unsigned commits

### DIFF
--- a/.github/workflows/sign-commits.yml
+++ b/.github/workflows/sign-commits.yml
@@ -1,0 +1,36 @@
+name: Sign Unsigned Commits
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  sign-commits:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node_modules-
+
+      - name: Sign all unsigned commits
+        uses: actions/commit@v2
+        with:
+          commit-message: 'Signed all unsigned commits'
+          signoff: true


### PR DESCRIPTION
Add a new GitHub Actions workflow to sign all unsigned commits.

* **Workflow Configuration**
  - Create a new file `.github/workflows/sign-commits.yml`
  - Define the workflow to trigger on push and pull request events to the `main` branch
  - Set the job to run on `ubuntu-latest`

* **Steps**
  - Check out the repository using `actions/checkout@v2`
  - Set up Node.js using `actions/setup-node@v2` with Node.js version 14
  - Cache `node_modules` using `actions/cache@v2`
  - Sign all unsigned commits using `actions/commit@v2` with a commit message 'Signed all unsigned commits' and signoff enabled

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Sinless777/Helix/pull/13?shareId=39190dec-a90f-473d-a882-56cc2b366448).