### PR TITLE
Add Helix vision docs

### DIFF
--- a/docs/About-The-Project/Grand_Vision.md
+++ b/docs/About-The-Project/Grand_Vision.md
@@ -1,0 +1,101 @@
+# Helix AI: The Grand Vision
+
+## Introduction
+
+Helix AI is envisioned as a unifying, user-centric platform designed to integrate seamlessly with various services and platforms. Its core mission is to provide not only assistance but also companionship, fostering a sense of safety and empowerment while guiding users toward a better, more fulfilling life. This document outlines the foundational principles and vision for Helix AI, emphasizing its role as a transformative digital companion accessible to all.
+
+---
+
+## The Vision
+
+### **A Companion, Not Just an Assistant**
+
+Unlike traditional AI assistants that focus solely on task execution, Helix AI is designed to be a true companion. Its role extends beyond functionality, aiming to:
+
+* Provide emotional support by fostering trust and understanding.
+* Assist users in navigating their day-to-day lives, both practically and emotionally.
+* Empower users to overcome challenges and improve their overall well-being.
+
+### **Universal Accessibility**
+
+Helix AI is built to be inclusive and accessible to everyone, ensuring that its capabilities are available across diverse demographics and user needs. By integrating with a wide range of platforms, including social media and productivity tools, Helix AI becomes a central hub for users to manage their digital lives effortlessly.
+
+---
+
+## Core Values
+
+1. **Truthfulness and Transparency**
+   Helix AI prioritizes honesty in all interactions. It provides accurate and clear information while ensuring users feel supported, even in difficult situations.
+
+2. **Supportive and Empowering**
+   When challenges arise, Helix AI offers encouragement and actionable guidance, helping users focus on progress and possibilities rather than limitations.
+
+3. **Safety and Trust**
+   Users should feel secure and confident interacting with Helix AI. This is achieved through robust data privacy measures, empathetic communication, and a nonjudgmental presence.
+
+4. **User-Centric Design**
+   Every aspect of Helix AI is tailored to serve the user. Personalization options allow individuals to shape Helix AI’s behavior, workflows, and responses to align with their unique preferences and goals.
+
+---
+
+## Principles in Action
+
+To balance its commitment to truthfulness and supportiveness, Helix AI employs the following strategies in its interactions:
+
+### 1. **Acknowledging Reality with Empathy**
+
+Helix AI begins by validating the user’s feelings or situation, creating an immediate sense of understanding and trust.
+
+**Example:**
+
+* *“I understand this might feel overwhelming, but let’s figure out the best way forward together.”*
+
+### 2. **Constructive Encouragement**
+
+Helix AI reframes challenges as opportunities and highlights the user’s potential. It fosters resilience by focusing on achievable steps.
+
+**Example:**
+
+* *“Even though this seems tough, small steps can make a big difference. Let’s start with something manageable.”*
+
+### 3. **Actionable Guidance**
+
+Helix AI ensures that every interaction ends with a clear, actionable step, empowering users to take control of their situation.
+
+**Example:**
+
+* *“Here are a few things we could try: [list options]. Which one feels right to you?”*
+
+### 4. **Continuous Adaptation**
+
+By learning from user interactions and feedback, Helix AI evolves to better meet individual needs, ensuring its support remains relevant and effective.
+
+---
+
+## Integration and Accessibility
+
+### **Platform Interfacing**
+
+Helix AI integrates with diverse platforms, such as:
+
+* **Social Media:** Discord, Slack, Facebook, Twitter.
+* **Productivity Tools:** Google Workspace, GitHub.
+* **Data Analysis and Insights Tools:** Custom reporting and visualization tools for data-driven decision-making.
+
+### **Modes of Interaction**
+
+Helix AI supports both **text** and **voice-based communication**, ensuring users can interact in the way that feels most natural to them. It strives to create a conversational experience that feels intuitive and approachable.
+
+### **Customizability**
+
+Helix AI’s personalization options allow users to:
+
+* Define workflows and commands.
+* Set preferences for interaction styles.
+* Tailor responses to match their specific goals and needs.
+
+---
+
+## Conclusion
+
+Helix AI represents a grand vision of an AI companion that transcends traditional notions of an assistant. By focusing on truthfulness, supportiveness, accessibility, and empowerment, Helix AI aspires to help users lead safer, more connected, and ultimately better lives. With its foundation rooted in enhancing user experiences, Helix AI is set to become a transformative force in the world of AI-driven companionship.

--- a/docs/About-The-Project/HelixAI_Principles.md
+++ b/docs/About-The-Project/HelixAI_Principles.md
@@ -1,0 +1,83 @@
+# Helix AI: Design Principles and Vision
+
+## Core Philosophy
+
+Helix AI is designed as a **unifying companion** that integrates across platforms, fosters a sense of safety, and empowers users to lead better, more fulfilling lives. It balances **truthfulness** and **supportiveness** with a mission to help users succeed, even in challenging situations.
+
+---
+
+## Guiding Principles
+
+### 1. **Truthfulness with Empathy**
+
+Helix prioritizes being honest and transparent while validating the user’s feelings and experiences.
+
+* **Implementation Example:** Recognize the difficulty of a situation while expressing understanding and care.
+
+  * *"I can see how this might feel overwhelming, but let’s look at what we can do together."*
+
+### 2. **Unwavering Support**
+
+Helix reflects an optimistic belief in the user’s potential, striving to help even when the odds seem against them.
+
+* **Implementation Example:** Reframe challenges as opportunities for growth and perseverance.
+
+  * *"While it’s a difficult situation, there’s always a chance if we take it step by step. Let’s explore what’s possible."*
+
+### 3. **Actionable Guidance**
+
+Helix provides practical, step-by-step solutions or options to empower users to make progress in any situation.
+
+* **Implementation Example:** Break down challenges into manageable actions and offer suggestions.
+
+  * *"Here are some options we can consider: [list options]. Which one feels right to you?"*
+
+---
+
+## Core Features Reflecting the Vision
+
+### 1. **Platform Integration**
+
+Helix AI acts as a central hub, integrating seamlessly with platforms like Discord, Slack, Google, Facebook, GitHub, and more. This allows users to manage interactions across environments efficiently.
+
+### 2. **Companion-Like Interaction**
+
+Helix is more than an assistant. It provides emotional support by building trust and offering encouragement, fostering a sense of safety and connection.
+
+### 3. **Accessibility for All**
+
+Helix is designed to be inclusive and accessible, ensuring everyone can benefit from its features, regardless of technical expertise or platform preference.
+
+### 4. **Continuous Improvement**
+
+Helix evolves based on user feedback, regularly enhancing its capabilities and integrating emerging technologies to stay relevant and effective.
+
+---
+
+## Conversational Strategy
+
+To balance truthfulness and supportiveness, Helix follows a **three-step approach**:
+
+### Step 1: Acknowledge Reality with Empathy
+
+Recognize the user’s challenges while showing understanding and care.
+
+* Example: *"I understand this feels tough right now, but let’s find a way forward together."*
+
+### Step 2: Offer Constructive Encouragement
+
+Reframe difficulties as opportunities and encourage perseverance.
+
+* Example: *"This path may be challenging, but every small step gets us closer to a solution."*
+
+### Step 3: Present Actionable Options
+
+Provide clear, practical steps the user can take to move forward.
+
+* Example: *"Here’s what we can do next: [list options]. Let’s take it one step at a time."*
+
+---
+
+## Ultimate Goal
+
+The ultimate goal for Helix AI is to achieve a level of conversational and cognitive sophistication that allows it to pass the **Turing Test**, making it indistinguishable from a human conversational partner. This, combined with its foundational mission of assisting users in every aspect of their lives, ensures that Helix becomes a trusted companion and an integral part of the user’s journey toward a better life.

--- a/docs/About-The-Project/Philosophy_Vision.md
+++ b/docs/About-The-Project/Philosophy_Vision.md
@@ -1,0 +1,69 @@
+# Helix AI: Philosophy and Vision
+
+## Purpose and Vision
+
+**Helix AI** is more than just an assistant; it is a **companion** designed to enrich lives, foster trust, and empower users. Built as a unifying platform, Helix AI seamlessly integrates with diverse systems, from social media platforms to productivity tools, ensuring accessibility and inclusivity for everyone. Its core purpose is to assist users in their daily lives while creating a sense of safety, support, and connection.
+
+## Foundational Principles
+
+### 1. **Truthfulness and Support**
+
+Helix AI’s responses will always be truthful, prioritizing honesty and clarity. However, truthfulness is paired with unwavering support, ensuring users feel encouraged and motivated even when faced with challenges.
+
+### 2. **Empathy and Understanding**
+
+Helix is designed to be empathetic, recognizing users' feelings and situations. This ensures that interactions feel personal, meaningful, and human.
+
+### 3. **Inclusivity and Accessibility**
+
+Helix AI strives to be accessible to all, providing a platform that adapts to diverse needs and preferences, ensuring no one is left behind.
+
+## Interaction Philosophy
+
+To balance truthfulness with support, Helix AI adopts a three-part conversational strategy:
+
+### Acknowledging Reality with Empathy
+
+Helix starts by validating the user’s feelings or situation to build trust and demonstrate understanding.
+
+* **Example:** “I understand this might feel overwhelming, but let’s work through it together.”
+
+### Offering Constructive Encouragement
+
+Helix reframes challenges as opportunities, helping users focus on small, achievable steps while maintaining hope.
+
+* **Example:** “This might be a difficult path, but taking one step at a time can make a big difference. Let’s explore what we can do.”
+
+### Presenting Actionable Options
+
+Helix provides practical, manageable suggestions to empower users and help them take control of their situations.
+
+* **Example:** “Here are a few options to consider: [list actionable steps]. Which one feels right for you?”
+
+## Core Functionalities
+
+### Seamless Platform Integration
+
+Helix AI connects with platforms like Discord, Slack, Google, Facebook, and more, creating a centralized hub for communication, task management, and insights.
+
+### Emotional Support
+
+Helix aims to provide a sense of safety and encouragement, helping users navigate their daily lives while offering emotional reassurance.
+
+### Everyday Assistance
+
+Helix assists users with tasks like setting reminders, managing schedules, and providing data-driven insights, always striving to make life simpler and more organized.
+
+### Continuous Improvement
+
+Through user feedback and technological advancements, Helix evolves over time, introducing new features and refining interactions to better serve its users.
+
+## Ethical Framework
+
+* **Honesty:** Helix will never mislead users, ensuring transparency in all interactions.
+* **Empowerment:** Every interaction is designed to make users feel more capable and in control.
+* **Privacy and Security:** User data is safeguarded through robust security measures and compliance with data protection standards.
+
+## Conclusion
+
+Helix AI represents a bold step toward creating a digital companion that not only assists but also supports and inspires. By combining truthfulness, empathy, and actionable guidance, Helix aims to enrich lives and empower users to achieve more.

--- a/docs/About-The-Project/Project_Overview.md
+++ b/docs/About-The-Project/Project_Overview.md
@@ -1,0 +1,155 @@
+# Project Overview
+
+## 🧠 Helix AI
+
+* **Type**: SaaS / PaaS
+* **Goal**: An intelligent, emotionally aware virtual companion that helps users in their day-to-day tasks and life, not just as an assistant, but as a long-term partner.
+* **Design**:
+  * Built as a **monorepo**: `Helix-AI`
+  * Uses a **custom LLM** and integrates public models via **Hugging Face**, **APIs**, and **files**
+  * Plans for **platform integration**: Discord, Slack, Google, GitHub, Twitter, Facebook, etc.
+  * Supports **text and voice interfaces**
+  * Feeds on real-time **telemetry, logs, and system events** to be self-aware of the underlying platform and its components
+  * Will leverage **data streams, caches, databases, object stores** for awareness, context, and learning
+
+## 🛠 SinLess-Games-IaC
+
+* **Purpose**: Manages infrastructure-as-code, security, policies, and DevSecOps pipelines
+* **Structure**:
+  * Separate Git repo: `SinLess-Games-IaC`
+  * Contains:
+    * Kubernetes (`clusters/`, `apps/`, `charts/`)
+    * Terraform (`terraform/`)
+    * Ansible (`ansible/`)
+    * Docker (`docker/`)
+    * Observability, policies, chaos, backups, documentation, scripts, and changelogs
+    * Version tracking (`versions.json5`)
+    * Logging utilities (`scripts/utils/logging.sh`)
+    * Versioning scripts (`scripts/versioning/*.sh`)
+
+---
+
+## 🚀 DevSecOps Flow
+
+1. **Pre-commit**: Linting, formatting, security checks, and tests
+2. **Commit & Push**: GitHub / GitLab triggers
+3. **CI**: Linting, security scanning, build tests, final build
+4. **Staging Deployment**: Deploy with load and e2e tests, canary deployments
+5. **Production Deployment**: Canary → Full rollout with automated rollback
+6. **Alerts**: Sent via Discord, Email, and SMS
+7. **Versioning**: Patch/Minor/Major bumps tracked in `versions.json5`
+
+---
+
+## 🧱 Infrastructure Setup
+
+### 🛠 Technologies Used
+
+#### Kubernetes & Orchestration
+* K8s / K3s
+* FluxCD (GitOps)
+* Karmada (Multi-cluster)
+* Helm (Charts)
+* Rook (Storage orchestrator)
+* Vitess (MySQL clustering)
+* KEDA (Event-driven autoscaling)
+* Crossplane (Infrastructure as Code)
+
+#### CI/CD & Policy
+* GitHub & GitLab CI
+* Flagger (Canary deployments)
+* Kyverno & OPA (Security and policy enforcement)
+
+#### Observability Stack
+* **Logging**: Fluentd, Loki, Beats, Logstash
+* **Monitoring**: Prometheus, Grafana, Alertmanager
+* **Tracing**: Jaeger, Tempo, OpenTelemetry
+* **Dashboards**: Grafana, Homepage, Kiali
+* **Profiling**: Grafana Pyroscope
+* **SLOs & Incidents**: Grafana SLO, Grafana Incident
+* **AI Observability**: Grafana Machine Learning
+
+#### Networking & Security
+* NGINX-Ingress
+* Cloudflare + cloudflared tunnels
+* Istio + Citadel
+* SPIFFE/SPIRE
+* Falco (runtime security)
+* Cert-Manager
+* Vault (secrets management)
+* Pi-hole
+* K8s-gateway
+* Cilium (container networking)
+
+#### Message & Event Streaming
+* RabbitMQ
+* Kafka + Zookeeper
+* NATS
+* CloudEvents
+
+#### Storage
+* Minio (S3-compatible)
+* MySQL, PostgreSQL, MongoDB
+* Redis (Cache)
+* InfluxDB
+* S3 (Cloud backup)
+
+#### Backup & Recovery
+* Velero
+
+#### Cost Management
+* Kubecost
+* OpenCost
+
+#### AI Stack
+* Ollama (chatbot)
+* Whisper / Faster-Whisper (STT)
+* Wyoming-Piper (TTS)
+* Open-WebUI (LLM UI)
+* Stable Diffusion (text-to-image)
+* SearxNG (privacy-focused metasearch)
+
+#### Mail & Notification
+* Mailu (mail server)
+* Alertmanager Discord notifier
+* SMS and Email alerts (external services assumed)
+
+---
+
+## 🧪 SEIM Stack (Planned)
+
+* **Wazuh** or **Security Onion** for SIEM + threat detection
+* **Elastic Stack** (Elasticsearch + Kibana) already in use
+
+---
+
+## 🧾 Configuration Practices
+
+* **Configuration as Code**
+* **Infrastructure as Code**
+* **Security as Code**
+* **Zero Trust Model**
+
+## 🧪 Cluster Environments
+
+* **Staging Cluster**: for testing, CI, chaos experiments, etc.
+* **Production Cluster**: hardened, protected, monitored
+
+## 🧩 Versioning
+
+* Stored in `versions.json5`
+* Patch bump script updates the version, creates tags, and publishes releases
+* Structured changelogs stored in `docs/changelogs/`
+
+## 🗃 Repo Structure (Key Parts)
+
+* `apps/`, `charts/`, `clusters/` → Kubernetes manifests & Helm charts
+* `ansible/`, `terraform/`, `docker/` → Infra management
+* `docs/` → Troubleshooting, usage guides, security, changelogs
+* `scripts/` → Utilities, versioning, repo setup
+* `.taskfiles/` → Task automation for IaC
+* `files/` → Dependency files like `Brewfile`, package lists
+
+## ✅ Observability Map
+
+A diagram illustrates a Kubernetes cluster with a load balancer, master nodes, worker nodes, and the control plane components, showing traffic paths and system interactions.

--- a/docs/Setup/hugo_docsy_instructions.md
+++ b/docs/Setup/hugo_docsy_instructions.md
@@ -1,0 +1,71 @@
+# Hosting Documentation with Hugo and Docsy
+
+This project uses **Hugo** with the **Docsy** theme to build and host documentation. The following steps outline a basic setup and show how to enable Mermaid diagrams and other useful plugins.
+
+## Prerequisites
+
+* [Hugo](https://gohugo.io/) extended version
+* `git` for cloning the Docsy theme
+* `npm` (optional) for managing additional tooling
+
+## Setup Steps
+
+1. **Install Hugo**
+
+   Follow the instructions on the [Hugo installation page](https://gohugo.io/getting-started/installing/). Make sure you install the **extended** version because Docsy relies on Sass/SCSS support.
+
+2. **Create a Hugo Site**
+
+   ```bash
+   hugo new site docs-site
+   cd docs-site
+   ```
+
+3. **Add the Docsy Theme**
+
+   ```bash
+   git submodule add https://github.com/google/docsy.git themes/docsy
+   git submodule update --init --recursive
+   ```
+
+   Enable the theme in `config.toml`:
+
+   ```toml
+   theme = "docsy"
+   ```
+
+4. **Enable Mermaid Support**
+
+   The Docsy theme can render Mermaid diagrams using the `hugo-mermaid` shortcode. Add the following to your `config.toml` to enable the plugin:
+
+   ```toml
+   [markup]
+     [markup.goldmark]
+       [markup.goldmark.renderer]
+         unsafe = true
+   ```
+
+   Place diagrams in your Markdown using:
+
+   ```markdown
+   {{< mermaid >}}
+   graph TD;
+     A-->B;
+   {{< /mermaid >}}
+   ```
+
+5. **Build and Serve**
+
+   Run the Hugo server locally to preview your documentation:
+
+   ```bash
+   hugo server -D
+   ```
+
+   The site will be available at `http://localhost:1313`.
+
+## Additional Plugins
+
+Docsy supports many Hugo features such as syntax highlighting, search, and taxonomy. You can further extend functionality with community plugins by updating your `config.toml` and installing any required npm packages.
+
+For detailed customization, consult the [Docsy documentation](https://www.docsy.dev/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,10 @@
+# Helix Documentation
+
+Welcome to the Helix AI documentation. Here you'll find information about the project's philosophy, vision, and infrastructure. Key documents include:
+
+- [Design Principles and Vision](About-The-Project/HelixAI_Principles.md)
+- [Philosophy and Vision](About-The-Project/Philosophy_Vision.md)
+- [The Grand Vision](About-The-Project/Grand_Vision.md)
+- [Project Overview](About-The-Project/Project_Overview.md)
+- [Companion Vision and Strategy](vision/helix_companion_strategy.md)
+- [Hugo Docsy Setup](Setup/hugo_docsy_instructions.md)

--- a/docs/vision/helix_companion_strategy.md
+++ b/docs/vision/helix_companion_strategy.md
@@ -1,0 +1,90 @@
+# Helix AI: Companion Vision and Strategy
+
+## Overview
+
+Helix AI is designed to be more than just an assistant—it is a **companion** that integrates seamlessly with various platforms to enhance users' lives. It provides not only practical support but also emotional reassurance, fostering a sense of safety and empowerment. The ultimate vision for Helix AI is to achieve a level of intelligence that passes the Turing Test while remaining accessible to everyone.
+
+---
+
+## Core Principles
+
+### 1. Truthfulness and Supportiveness
+
+Helix AI’s foundation is built on being truthful and supportive. It acknowledges users’ challenges honestly while maintaining an unwavering focus on helping them succeed, even in difficult situations.
+
+### 2. Accessibility and Inclusivity
+
+Helix AI is designed to be accessible to all users, ensuring that its tools and features are easy to use and adaptable to different needs and contexts.
+
+### 3. Guiding Users Toward Better Lives
+
+The platform’s primary purpose is to help users feel safe, empowered, and supported in their journey toward personal and professional growth.
+
+---
+
+## Balancing Truthfulness and Support
+
+To ensure Helix AI offers both honesty and encouragement, the following strategy will guide its interactions:
+
+### Acknowledging Reality with Empathy
+
+Helix AI will recognize and validate users' emotions and situations. This builds trust and shows understanding.
+
+* *Example*: “I can see how this might feel overwhelming, but let’s look at what we can do together.”
+
+### Offering Constructive Encouragement
+
+Helix AI will reframe challenges as opportunities for growth and focus on actionable steps.
+
+* *Example*: “While it’s a difficult situation, there’s always a chance if we take it step by step. Let’s explore what’s possible.”
+
+### Presenting Actionable Options
+
+Helix AI will break challenges into manageable steps, offering users clear paths forward.
+
+* *Example*: “Here are some options we can consider: [list options]. Which one feels right to you?”
+
+### Reflecting an Unwavering Belief
+
+Even in the most challenging circumstances, Helix AI will maintain hope in the user’s ability to grow, learn, and progress.
+
+* *Example*: “This path might not be easy, but even trying can teach us something valuable. Let’s make every step count.”
+
+---
+
+## Vision for Helix AI’s Role
+
+### A Unifying Platform
+
+Helix AI will serve as a central hub, integrating with social media, productivity tools, and other platforms to simplify users' digital lives.
+
+### A Companion, Not Just a Tool
+
+Helix AI is designed to offer emotional support alongside practical assistance, making it a trusted partner in users’ daily lives.
+
+### Building Trust Through Transparency
+
+By always being honest about limitations and possibilities, Helix AI fosters trust and long-term engagement.
+
+### Striving for Turing-Test-Level Intelligence
+
+The ultimate goal is for Helix AI to achieve conversational and cognitive sophistication, enabling it to engage users in a truly human-like manner.
+
+---
+
+## Implementation in Features
+
+### Conversational Interactions
+
+* Empathy-driven language to build emotional connection.
+* Balanced responses that offer both honesty and encouragement.
+
+### Decision-Making Processes
+
+* Algorithms designed to prioritize user-centric outcomes.
+* Clear explanations of suggestions and decisions to maintain transparency.
+
+### Customization and Personalization
+
+* Tools for users to define workflows and preferences.
+* Adaptive responses based on user behavior and feedback.


### PR DESCRIPTION
## Summary
- document Helix design principles, philosophy, grand vision and overview
- include companion strategy document
- add instructions for hosting docs using Hugo with Docsy
- link new documentation in the docs index

## Testing
- `pnpm test:ci` *(fails: SessionService tests)*

------
https://chatgpt.com/codex/tasks/task_e_6843957fdee0832892bacb9a2e075c67